### PR TITLE
TranslatedFormMixin with associated tests and view modifications

### DIFF
--- a/atriaapp/atriacalendar/forms.py
+++ b/atriaapp/atriacalendar/forms.py
@@ -11,6 +11,6 @@ class EventForm(TranslationModelForm):
         model = Event
         fields = "__all__"
 
-    def __init__(self, *args, **kws):
-        super().__init__(*args, **kws)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.fields['description'].required = False

--- a/atriaapp/atriacalendar/templates/swingtime/event_detail.html
+++ b/atriaapp/atriacalendar/templates/swingtime/event_detail.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% load i18n %}
+
 {% block title %}Event: {{ event }}{% endblock %}
 {% block main_content %}
     <h3>Swingtime Event</h3>
     <h4>Event Details</h4>
-    {% language request.GET.event_lang %}
-        <form action="" method="post">{% csrf_token %}
+      <form action="" method="post">{% csrf_token %}
         <table>
             <tfoot>
                 <tr>
@@ -66,5 +66,4 @@
         </table>
         </form>
         </form>
-    {% endlanguage %}
 {% endblock %}


### PR DESCRIPTION
Doing it via the Mixin allows us to remove the `{% language <code> %}` from the templates, as the mixin ensures that the displayed `EventForm` obeys the language queryparameter and the subsequent `POST` sets the correct language fields on the model instance.