### PR TITLE
add permissions middleware for handling requests from users with roles

### DIFF
--- a/atriaapp/atriacalendar/middleware/URLPermissionsMiddleware.py
+++ b/atriaapp/atriacalendar/middleware/URLPermissionsMiddleware.py
@@ -1,0 +1,39 @@
+import re
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
+
+
+class URLPermissionsMiddleware:
+    """
+    Simple permissions middleware that checks permissions against URL regexes
+    according to settings.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if self.request_allowed(request):
+            return self.get_response(request)
+        else:
+            raise PermissionDenied
+
+    def request_allowed(self, request):
+        user = request.user
+        path = request.path
+        url_permissions = getattr(settings, 'URL_PERMISSIONS', [])
+
+        if user.is_anonymous:
+            return True
+
+        for url in url_permissions:
+            pattern, roles = url
+
+            if re.match(pattern, path):
+                for role in roles:
+                    if user.has_role(role):
+                        return True
+
+                return False
+
+        return True

--- a/atriaapp/atriacalendar/middleware/__init__.py
+++ b/atriaapp/atriacalendar/middleware/__init__.py
@@ -1,0 +1,1 @@
+from .URLPermissionsMiddleware import URLPermissionsMiddleware

--- a/atriaapp/atriacalendar/tests/__init__.py
+++ b/atriaapp/atriacalendar/tests/__init__.py
@@ -1,0 +1,2 @@
+from .model_tests import UserTests, TranslationTests, EventTests
+from .middleware_tests import URLPermissionsMiddlewareTests

--- a/atriaapp/atriacalendar/tests/middleware_tests.py
+++ b/atriaapp/atriacalendar/tests/middleware_tests.py
@@ -1,0 +1,76 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase, modify_settings
+
+from ..middleware import URLPermissionsMiddleware
+
+User = get_user_model()
+
+
+@modify_settings(
+    MIDDLEWARE={'append': 'atriacalendar.middleware.URLPermissionsMiddleware'},
+    URL_PERMISSIONS={'append': [
+        (r'/neighbour/.*', ('Volunteer', 'Attendee')),
+        (r'/organization/.*', ('Admin',)),
+    ]},
+)
+class URLPermissionsMiddlewareTests(TestCase):
+    PASSWORD = 'example'
+
+    def setUp(self):
+        for role in ('Attendee', 'Volunteer', 'Admin'):
+            setattr(self, role.lower(), User.objects.create(
+                email='%s@example.com' % role.lower(),
+                first_name=role,
+                last_name='User'
+            ))
+
+            user = getattr(self, role.lower())
+
+            user.add_role(role)
+            user.set_password(self.PASSWORD)
+            user.save()
+
+    def request_url_as_user(self, user, url):
+        # import pdb; pdb.set_trace()
+        self.client.login(email=user.email, password=self.PASSWORD)
+
+        return self.client.get(url)
+
+    def test_attendee_ok(self):
+        # TODO: change expected status code to 200 once URL is implemented
+        response = self.request_url_as_user(self.attendee,
+                                            '/neighbour/dashboard/')
+
+        self.assertEqual(404, response.status_code)
+
+    def test_attendee_forbidden(self):
+        response = self.request_url_as_user(self.attendee,
+                                            '/organization/dashboard/')
+
+        self.assertEqual(403, response.status_code)
+
+    def test_volunteer_ok(self):
+        # TODO: change expected status code to 200 once URL is implemented
+        response = self.request_url_as_user(self.volunteer,
+                                            '/neighbour/dashboard/')
+
+        self.assertEqual(404, response.status_code)
+
+    def test_volunteer_forbidden(self):
+        response = self.request_url_as_user(self.volunteer,
+                                            '/organization/dashboard/')
+
+        self.assertEqual(403, response.status_code)
+
+    def test_admin_ok(self):
+        # TODO: change expected status code to 200 once URL is implemented
+        response = self.request_url_as_user(self.admin,
+                                            '/organization/dashboard/')
+
+        self.assertEqual(404, response.status_code)
+
+    def test_admin_forbidden(self):
+        response = self.request_url_as_user(self.admin,
+                                            '/neighbour/dashboard/')
+
+        self.assertEqual(403, response.status_code)

--- a/atriaapp/atriacalendar/tests/model_tests.py
+++ b/atriaapp/atriacalendar/tests/model_tests.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import translation
@@ -7,9 +6,9 @@ from django.views.generic.edit import UpdateView
 
 from swingtime.models import EventType
 
-from .forms import AtriaEventForm
-from .models import AtriaEvent, AtriaEventProgram, USER_ROLES
-from .views import EventUpdateView, TranslatedFormMixin
+from ..forms import AtriaEventForm
+from ..models import AtriaEvent, AtriaEventProgram, USER_ROLES
+from ..views import EventUpdateView, TranslatedFormMixin
 
 User = get_user_model()
 


### PR DESCRIPTION
Currently uses a django settings variable called `URL_PERMISSIONS`, which is an iterable of couples – see the `@modify_settings` args in tests/middleware_tests.py. Can be modified in the future to use a database table.

_Must_ be added to `settings.MIDDLEWARE_CLASSES` _after_ any authentication middleware, otherwise there will be no effect, as the requesting user won't be identified yet.

Tests may break in future if the test URLs are defined. Can either modify the tests to ignore the project's urlconf, or change the asserts to expect 200 instead of 404 when the user has permission.